### PR TITLE
Feature - Adição do tempo para fixar

### DIFF
--- a/include/Game.hpp
+++ b/include/Game.hpp
@@ -43,6 +43,8 @@ class Game{
     void DrawHoldShape();
     void DrawNextShapes();
     bool HasLost();
+    int tickToFix;
+    int maxTickToFix;
     Shape shapes[7] = {I_Shape(board),
                        O_Shape(board),
                        T_Shape(board),

--- a/include/Shape.hpp
+++ b/include/Shape.hpp
@@ -57,11 +57,13 @@ public:
   const Board& board;
   const int index;
   const Vec2<int> downAddVector = {0, 1};
+  const Vec2<int> upAddVector = {0, -1};
   const Vec2<int> rightAddVector = {1, 0};
   const Vec2<int> leftAddVector = {-1, 0};
   int GetRightestXCell();
   int GetLeftestXCell();
   int GetLowestYCell();
+  int GetHighestYCell();
   bool HasCellRight();
   bool HasCellLeft();
   bool HasCellDown();
@@ -69,6 +71,8 @@ public:
   int GetFirstRightCollisionX(Vec2<int>);
   int GetDistanceFromTheGround(Vec2<int>) const;
   int GetShortestDistanceFromTheGround() const;
+  void Move(int, int);
+  bool HasCollided(Vec2<int>);
 };
 
 class I_Shape : public Shape{

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -16,6 +16,8 @@ Game::Game(Board board) :
   level = 0;
   speed = 15;
   cleanedLinesCount = 0;
+  maxTickToFix = 30;
+  tickToFix = maxTickToFix;
 }
 
 bool Game::GameShouldClose() const{
@@ -94,6 +96,8 @@ void Game::DropLine(int line) {
 
 void Game::UpdateShape(){
   if (shape->WillCollideDown()){
+    tickToFix--;
+    if(tickToFix) return;
     Vec2<int> cellPosition;
     int dimension = shape->GetDimension();
     for (int x = 0; x < dimension; ++x){
@@ -108,6 +112,8 @@ void Game::UpdateShape(){
     shape = NextShape();
     canHold = true;
   }
+  if(tickToFix > maxTickToFix || !tickToFix) tickToFix = maxTickToFix;
+  if(tickToFix < maxTickToFix) tickToFix--;
 }
 
 void Game::Draw(){
@@ -133,11 +139,13 @@ void Game::UpdateBoard(){
     case KEY_SPACE:
       fallen = shape->InstantFall();
       UpdateScore(2 * fallen);
-      break;
+      tickToFix = 1;
+      return;
     case KEY_W:
       if(shape->HasSpaceToRotate()){
         shape->Rotate();
         shape->MoveIfCollided();
+        tickToFix++;
       }
       break;
     case KEY_C:
@@ -152,14 +160,23 @@ void Game::UpdateBoard(){
     auto keyDown = ray_functions::GetKeyDown();
     switch(keyDown){
       case KEY_D:
-        if (!shape->WillCollideRight()){shape->MoveRight();}
+        if (!shape->WillCollideRight()){
+          shape->MoveRight();
+          shape->MoveIfCollided();
+          tickToFix++;
+        }
         break;
       case KEY_A:
-        if (!shape->WillCollideLeft()) {shape->MoveLeft();}
+        if (!shape->WillCollideLeft()) {
+          shape->MoveLeft();
+          shape->MoveIfCollided();
+          tickToFix++;
+        }
         break;
       case KEY_S:
         if (!shape->WillCollideDown()){
           shape->MoveDown();
+          shape->MoveIfCollided();
           UpdateScore(1);
         }
       default:
@@ -225,7 +242,10 @@ int Game::QuantityOfLines(){
 void Game::UpdateLevel(){
   if(cleanedLinesCount >= 10 * (level + 1) && level < 29){
     level++;
-    if(level <= 10 || level == 13 || level == 16 || level == 19 || level == 29){ speed--;}
+    if(level <= 10 || level == 13 || level == 16 || level == 19 || level == 29){
+      speed--;
+      maxTickToFix -= 2;
+    }
   }
 }
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -97,7 +97,7 @@ void Game::DropLine(int line) {
 void Game::UpdateShape(){
   if (shape->WillCollideDown()){
     tickToFix--;
-    if(tickToFix) return;
+    if(tickToFix > 0) return;
     Vec2<int> cellPosition;
     int dimension = shape->GetDimension();
     for (int x = 0; x < dimension; ++x){
@@ -112,7 +112,7 @@ void Game::UpdateShape(){
     shape = NextShape();
     canHold = true;
   }
-  if(tickToFix > maxTickToFix || !tickToFix) tickToFix = maxTickToFix;
+  if(tickToFix > maxTickToFix || tickToFix <= 0) tickToFix = maxTickToFix;
   if(tickToFix < maxTickToFix) tickToFix--;
 }
 


### PR DESCRIPTION
## Descrição:

Agora a peça não fixa automaticamente ao tocar em alguma superfície, quando ela entra em contato com alguma superfície um tempo começa a ser contabilizado e ela só vai fixar após esse tempo acabar, fazer movimentos pode aumentar um pouco esse tempo.

### Recomendo que a gente fique jogando bastante pra ver se tanto o tempo para fixar quanto o tempo que é acrescido quando o jogador faz um movimento parecem bons.