### PR TITLE
Consertando o erro dos controles e adicionando coisas

### DIFF
--- a/include/Coop.hpp
+++ b/include/Coop.hpp
@@ -7,7 +7,6 @@ class Coop : public Game {
   public:
     Coop(Board *board);
     Coop(Board *board, int skin);
-    void Tick() override;
   private:
     void Draw() override;
     Shape i, o, t, j, l, s, z;

--- a/include/CoopOptions.hpp
+++ b/include/CoopOptions.hpp
@@ -20,6 +20,9 @@ class CoopOptions : public SoloOptions{
     bool CoopOptionsHandling();
     void ReadyButtonsHandling();
     bool SkinSelectorHandling();
+    void ChangeSelectedSkin(int index);
+    void SkinPreview(int index);
+    bool ChangeSkin(int index);
     void ControlButtonsHandling();
     void BgSelectorHandling();
     void Close(Screens screen);

--- a/include/OptionsButton.hpp
+++ b/include/OptionsButton.hpp
@@ -16,6 +16,9 @@ public:
   std::string GetButtonText();
   void SetButtonText(std::string);
   void SetCurrentSelectedOptionIndex(int);
+  bool HasButtonSelected();
+  int GetButtonSelected();
+  bool GetIsMenuOpen();
 private:
   void MenuHandling();
   void Update() override;

--- a/include/Screen.hpp
+++ b/include/Screen.hpp
@@ -18,6 +18,7 @@ public:
 protected:
   bool shouldClose = true;
   virtual void Draw();
+  void GoToScreen(Screens screen);
   Screens nextScreen;
   Music music;
   std::string musicPath;

--- a/include/SoloOptions.hpp
+++ b/include/SoloOptions.hpp
@@ -20,17 +20,19 @@ class SoloOptions : public Screen{
   private:
     void Draw() override;
     bool SoloOptionsHandling();
-    void Close(Screens screen);
     void ScreenButtonsHandling();
     void BgSelectorHandling();
     bool SkinSelectorHandling();
+    void SkinPreview();
+    void ChangeSelectedSkin();
+    bool ChangeSkin();
     void InputTextHandling();
     void InputTextSettings();
     void SetBoardPosition();
     std::string GetKeyboardInput();
     std::string selectedSkin = skinNames[settings::db["SKIN"]];
     Board board;
-    Shape *shape;
+    Shape *shape = nullptr;
     OptionsButton skinSelector;
     ScreenButton inputText;
     ScreenButton backgroundSelector;

--- a/src/Coop.cpp
+++ b/src/Coop.cpp
@@ -24,25 +24,6 @@ void Coop::SetPlayers(){
   players[1] = player2;
 }
 
-void Coop::Tick(){
-  if(HasLost()){
-    nextScreen = GAMEOVER;
-    OpenClose();
-    return;
-  }
-  if(IsMusicReady(music) && IsMusicStreamPlaying(music)) {UpdateMusicStream(music);}
-  BeginDrawing();
-  Update();
-  if(!HasLost()){
-    ClearLines();
-    Draw();
-    Score();
-    DropLines();
-  }
-  EndDrawing();
-  tickCount++;
-}
-
 void Coop::Draw(){
   ClearBackground(BLACK);
   float scale = (GetScreenWidth() * 1.2)/(float)backgroundTexture->width;
@@ -72,7 +53,7 @@ void Coop::UpdatePlayer(int index){
     Game::Update(player2);
     return;
   }
-  Game::Update();
+  Game::Update(player);
 }
 
 Shape *Coop::NextShape(Player* player){

--- a/src/CoopOptions.cpp
+++ b/src/CoopOptions.cpp
@@ -48,10 +48,7 @@ void CoopOptions::Tick(){
   buttonManager->Tick();
   EndDrawing();
   if(GetKeyPressed() == KEY_ESCAPE) Close(MENU);
-  if(returnButton.isButtonClicked()){
-    Close(MENU);
-    returnButton.Unclick();
-  }
+  if(returnButton.isButtonClicked()) Close(MENU);
 }
 
 void CoopOptions::Draw(){
@@ -79,18 +76,33 @@ bool CoopOptions::CoopOptionsHandling(){
 }
 
 bool CoopOptions::SkinSelectorHandling(){
-  string skinString;
-  int skinIndex;
   for(int i = 0; i < 2; i++){
-    skinString = skinSelector[i].GetText();
-    for(skinIndex = 0; skinIndex < skinNames.size(); skinIndex++) if(skinNames[skinIndex] == skinString) break;
-    db["COOPSKINS"][i] = skinIndex;
-    selectedSkin[i] = skinString;
-    delete shapes[i];
-    shapes[i] = new L_Shape(boards[i], db["COOPSKINS"][i]);
-    if(!shapes[i]) return true;
-    shapes[i]->Fall();
+    if(!skinSelector[i].GetIsMenuOpen()) ChangeSelectedSkin(i);
+    if(skinSelector[i].HasButtonSelected()) SkinPreview(i);
+    bool error = ChangeSkin(i);
+    if(error) return true;
   }
+  return false;
+}
+
+void CoopOptions::ChangeSelectedSkin(int index){
+  int skinIndex;
+  string skinString = skinSelector[index].GetText();
+  for(skinIndex = 0; skinIndex < skinNames.size(); skinIndex++) if(skinNames[skinIndex] == skinString) break;
+  db["COOPSKINS"][index] = skinIndex;
+  selectedSkin[index] = skinString;
+}
+
+void CoopOptions::SkinPreview(int index){
+  int skinIndex = skinSelector[index].GetButtonSelected();
+  db["COOPSKINS"][index] = skinIndex;
+}
+
+bool CoopOptions::ChangeSkin(int index){
+  delete shapes[index];
+  shapes[index] = new L_Shape(boards[index], db["COOPSKINS"][index]);
+  if(!shapes[index]) return true;
+  shapes[index]->Fall();
   return false;
 }
 
@@ -121,16 +133,18 @@ void CoopOptions::ReadyButtonsHandling(){
       readyButtons[i].SetColor(color);
     }
   }
-  if(clicked[0] == clicked[1] && clicked[0]) Close(COOP);
+  if(clicked[0] == clicked[1] && clicked[0]){
+    Close(COOP); 
+  }
 }
 
 void CoopOptions::Close(Screens screen){
-  nextScreen = screen;
-  OpenClose();
+  GoToScreen(screen);
   for(int i = 0; i < 2; i++){
     clicked[i] = false;
     readyButtons[i].SetColor(RED);
   }
+  returnButton.Unclick();
 }
 
 void CoopOptions::SetBoardsPosition(){

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -50,18 +50,21 @@ int Game::SetSpeed(){
 
 void Game::Tick(){
   if(HasLost()){
-    nextScreen = GAMEOVER;
-    OpenClose();
+    GoToScreen(GAMEOVER);
+    return;
+  }
+  if(!IsWindowFocused()){
+    GoToScreen(PAUSE);
     return;
   }
   if(IsMusicReady(music) && IsMusicStreamPlaying(music)) {UpdateMusicStream(music);}
   BeginDrawing();
-  Game::Update();
+  Update();
   if(!HasLost()){
-    Game::ClearLines();
-    Game::Draw();
-    Game::Score();
-    Game::DropLines();
+    ClearLines();
+    Draw();
+    Score();
+    DropLines();
   }
   EndDrawing();
   tickCount++;
@@ -180,6 +183,7 @@ void Game::DrawPontuation(){
 }
 
 void Game::Update(){
+  if(player->control != settings::db["CONTROL"]) player->control = settings::db["CONTROL"];
   Update(player);
 }
 
@@ -442,3 +446,4 @@ void Game::DrawStats(int firstValue) const{
     ray_functions::DrawText(numStr, Vec2<double>{xPos,yPos}, screenHeight * 1/25, RAYWHITE);
   }
 }
+

--- a/src/OptionsButton.cpp
+++ b/src/OptionsButton.cpp
@@ -91,3 +91,23 @@ Vec2<double> OptionsButton::GetMenuWidthHeight(){
 void OptionsButton::SetCurrentSelectedOptionIndex(int index){
   currentSelectedOptionIndex = index;
 }
+
+bool OptionsButton::HasButtonSelected(){
+  for(Button *button : buttonOptions->GetButtons()){
+    if(button->isSelected) return true;
+  }
+  return false;
+}
+
+int OptionsButton::GetButtonSelected(){
+  int i = -1;
+  for(Button *button : buttonOptions->GetButtons()){
+    i++;
+    if(button->isSelected) break;
+  }
+  return i;
+}
+
+bool OptionsButton::GetIsMenuOpen(){
+  return isMenuOpen;
+}

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -44,3 +44,8 @@ Screens Screen::GetScreen(){ return nextScreen;}
 void Screen::SetNextScreen(Screens newNextScreen){
   nextScreen = newNextScreen;
 }
+
+void Screen::GoToScreen(Screens screen){
+  nextScreen = screen;
+  OpenClose();
+}

--- a/src/SoloOptions.cpp
+++ b/src/SoloOptions.cpp
@@ -117,12 +117,27 @@ string SoloOptions::GetKeyboardInput(){
 }
 
 bool SoloOptions::SkinSelectorHandling(){
+  if(!skinSelector.GetIsMenuOpen()) ChangeSelectedSkin();
+  if(skinSelector.HasButtonSelected()) SkinPreview();
+  bool error = ChangeSkin();
+  return error;
+}
+
+void SoloOptions::ChangeSelectedSkin(){
   string skinString;
   int skinIndex;
   skinString = skinSelector.GetText();
   for(skinIndex = 0; skinIndex < skinNames.size(); skinIndex++) if(skinNames[skinIndex] == skinString) break;
-  db["SKIN"] = skinIndex;
   selectedSkin = skinString;
+  db["SKIN"] = skinIndex;
+}
+
+void SoloOptions::SkinPreview(){
+  int index = skinSelector.GetButtonSelected();
+  db["SKIN"] = index;
+}
+
+bool SoloOptions::ChangeSkin(){
   delete shape;
   shape = new L_Shape(board, db["SKIN"]);
   if(!shape) return true;
@@ -132,18 +147,13 @@ bool SoloOptions::SkinSelectorHandling(){
 
 void SoloOptions::ScreenButtonsHandling(){
   if(GetKeyPressed() == KEY_ESCAPE || returnButton.isButtonClicked()){
-    Close(MENU);
+    GoToScreen(MENU);
     returnButton.Unclick();
   }
   if(play.isButtonClicked()){
-    Close(GAME);
+    GoToScreen(GAME);
     play.Unclick();
   }
-}
-
-void SoloOptions::Close(Screens screen){
-  nextScreen = screen;
-  OpenClose();
 }
 
 void SoloOptions::SetBoardPosition(){


### PR DESCRIPTION
## Descrição:

Agora os controles do modo solo mudados durante o pause realmente se aplicam ao jogo
Agora é possível ver a skin apenas passando o mouse por cima do nome da skin
Agora quando a janela do jogo não é a principal ele pausa automaticamente